### PR TITLE
fix: add worker routes for domain routing

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,10 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "eldspire-www",
   "compatibility_date": "2025-09-02",
+  "routes": [
+    { "pattern": "eldspire.com/*", "zone_name": "eldspire.com" },
+    { "pattern": "www.eldspire.com/*", "zone_name": "eldspire.com" }
+  ],
   "compatibility_flags": [
     "nodejs_compat"
   ],


### PR DESCRIPTION
## Summary
- Adds explicit worker routes for `eldspire.com` and `www.eldspire.com` in wrangler.jsonc
- Fixes 522 error on www.eldspire.com by routing through the worker instead of expecting an origin server

🤖 Generated with [Claude Code](https://claude.com/claude-code)