### PR TITLE
feat: add D1 read replica support

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,17 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "eldspire-www",
+  "preview_urls": true,
   "compatibility_date": "2025-09-02",
   "routes": [
-    { "pattern": "eldspire.com/*", "zone_name": "eldspire.com" },
-    { "pattern": "www.eldspire.com/*", "zone_name": "eldspire.com" }
+    {
+      "pattern": "eldspire.com/*",
+      "zone_name": "eldspire.com"
+    },
+    {
+      "pattern": "www.eldspire.com/*",
+      "zone_name": "eldspire.com"
+    }
   ],
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
## Summary
- Add D1 read replica support using `withSession()` for page queries
- Read `x-d1-bookmark` header to maintain session consistency across requests
- Enables lower latency reads from geographically closer replicas

🤖 Generated with [Claude Code](https://claude.com/claude-code)