### PR TITLE
feat: optimized sync with wikilink prefix stripping

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "deploy": "bun run build && wrangler deploy",
     "cf-typegen": "wrangler types",
-    "sync": "bun scripts/sync-vault.ts"
+    "sync": "bun scripts/sync-vault.ts",
+    "sync:build": "bun build --compile scripts/sync-vault.ts --outfile eldspire && sudo mv eldspire /usr/local/bin/"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.6",

--- a/scripts/sync-vault.test.ts
+++ b/scripts/sync-vault.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import {
   hasPublishTag,
   stripTags,
+  stripWikilinkPrefixes,
   parseTitle,
   findMarkdownFiles,
   collectPages,
@@ -75,6 +76,27 @@ Some content here`;
 
   it("handles content with no tags", () => {
     expect(stripTags("Just plain content")).toBe("Just plain content");
+  });
+});
+
+describe("stripWikilinkPrefixes", () => {
+  it("strips ID prefix from wikilinks", () => {
+    expect(stripWikilinkPrefixes("[[04.99.06 Ashenport]]")).toBe("[[Ashenport]]");
+    expect(stripWikilinkPrefixes("[[1.2.3 Short]]")).toBe("[[Short]]");
+  });
+
+  it("preserves display text", () => {
+    expect(stripWikilinkPrefixes("[[04.99.06 Ashenport|The Port]]")).toBe("[[Ashenport|The Port]]");
+  });
+
+  it("handles multiple wikilinks", () => {
+    const content = "See [[04.99.06 Ashenport]] and [[01.02.03 Other Place]]";
+    expect(stripWikilinkPrefixes(content)).toBe("See [[Ashenport]] and [[Other Place]]");
+  });
+
+  it("leaves wikilinks without prefix unchanged", () => {
+    expect(stripWikilinkPrefixes("[[Ashenport]]")).toBe("[[Ashenport]]");
+    expect(stripWikilinkPrefixes("[[Some Page|Display]]")).toBe("[[Some Page|Display]]");
   });
 });
 

--- a/scripts/sync-vault.ts
+++ b/scripts/sync-vault.ts
@@ -28,6 +28,15 @@ export function stripTags(content: string): string {
 }
 
 /**
+ * Strip ID prefixes from wikilinks in content
+ * [[04.99.06 Ashenport]] -> [[Ashenport]]
+ * [[04.99.06 Ashenport|Custom Display]] -> [[Ashenport|Custom Display]]
+ */
+export function stripWikilinkPrefixes(content: string): string {
+  return content.replace(/\[\[(\d+\.\d+\.\d+\s+)([^\]|]+)(\|[^\]]+)?\]\]/g, "[[$2$3]]");
+}
+
+/**
  * Strip the numeric ID prefix from a filename to get the page name
  */
 export function parseTitle(filename: string): string {
@@ -75,7 +84,7 @@ export async function collectPages(vaultPath: string, publishTag: string): Promi
       const filename = basename(filePath);
       const name = parseTitle(filename);
 
-      pages.push({ name, content: stripTags(content) });
+      pages.push({ name, content: stripWikilinkPrefixes(stripTags(content)) });
     }
   }
 

--- a/scripts/sync-vault.ts
+++ b/scripts/sync-vault.ts
@@ -100,15 +100,15 @@ export async function syncToApi(pages: Page[], apiUrl: string): Promise<SyncResu
   return response.json();
 }
 
-async function main() {
-  const vaultPath = process.env.OBSIDIAN_VAULT_PATH;
-  const publishTag = process.env.SYNC_TAG ?? "wiki";
-  const apiUrl = process.env.SYNC_API_URL;
+// Default configuration (bundled into binary)
+const DEFAULT_VAULT_PATH = "/Users/byronguina/Library/Mobile Documents/iCloud~md~obsidian/Documents/Zaum";
+const DEFAULT_API_URL = "https://eldspire.com";
+const DEFAULT_TAG = "wiki";
 
-  if (!vaultPath) {
-    console.error("Error: OBSIDIAN_VAULT_PATH environment variable is required");
-    process.exit(1);
-  }
+async function main() {
+  const vaultPath = process.env.OBSIDIAN_VAULT_PATH ?? DEFAULT_VAULT_PATH;
+  const publishTag = process.env.SYNC_TAG ?? DEFAULT_TAG;
+  const apiUrl = process.env.SYNC_API_URL ?? DEFAULT_API_URL;
 
   // Check vault exists
   try {
@@ -134,11 +134,6 @@ async function main() {
 
   if (pages.length === 0) {
     console.log("No pages to sync.");
-    return;
-  }
-
-  if (!apiUrl) {
-    console.log("\nDry run mode (SYNC_API_URL not set)");
     return;
   }
 


### PR DESCRIPTION
## Summary
- Batch D1 writes for better performance (single query to check existing pages, single batch for all inserts/updates)
- Strip ID prefixes from wikilinks at sync time (`[[04.99.06 Ashenport]]` → `[[Ashenport]]`)
- Bundle default config into CLI binary (vault path, API URL, tag)
- Add `sync:build` script to compile standalone binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)